### PR TITLE
make setup compatible with pipx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from os import path
-from setuptools import setup
+from setuptools import find_packages, setup
 
 wd = path.abspath(path.dirname(__file__))
 with open(path.join(wd, 'README.md'), encoding='utf-8') as f:
@@ -19,8 +19,9 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords=['aws', 'ssm', 'parameter-store'],
-    packages=['states'],
-    scripts=['ssm-diff'],
+    packages=find_packages(),
+    scripts=[],
+    entry_points={'console_scripts': ['ssm-diff=ssmdiff.main:main']},
     install_requires=[
         'termcolor',
         'boto3',

--- a/ssmdiff/main.py
+++ b/ssmdiff/main.py
@@ -66,7 +66,7 @@ def plan(args):
     print(DiffBase.describe_diff(remote.dry_run(local.get())))
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-f', help='local state yml file', action='store', dest='filename')
     parser.add_argument('--engine', '-e', help='diff engine to use when interacting with SSM', action='store', dest='engine', default='DiffResolver')
@@ -117,3 +117,6 @@ if __name__ == "__main__":
     args.filename = filename
 
     args.func(args)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I like using [pipx](https://pipxproject.github.io/pipx/) to install my tools in a dedicated venv.

In order to do this it is necessary to configure an entry point in the setup.py